### PR TITLE
Add feature : 라이어게임 화면 구현

### DIFF
--- a/src/components/LiarGame/AnswerViewComponent.js
+++ b/src/components/LiarGame/AnswerViewComponent.js
@@ -1,0 +1,46 @@
+import React, {useEffect, useState} from 'react'
+import WinLiarComponent from "./WinLiarComponent";
+
+// 정답 화면을 보여주는 컴포넌트, 3초 뒤 라이어 승리 컴포넌트로 이동
+const AnswerViewComponent = (props) => {
+
+    const [changeComponent, setChangeComponent] = useState(false);
+
+    useEffect(() => {
+        let counter = 0;
+        let interval = setInterval(function () {
+            counter++;
+            if (counter === 3) {
+                clearInterval(interval);
+                setChangeComponent(true);
+
+            }
+        }, 1000);
+    }, []);
+
+    if (!changeComponent) {
+        return (
+            <>
+                <div style={styles.container}><span style={styles.answer}>정 - 답</span></div>
+            </>
+        )
+    } else {
+        return (
+            <>
+                <WinLiarComponent name={props.name} profile={props.profile}/>
+            </>
+        )
+    }
+}
+
+export default AnswerViewComponent
+
+const styles = {
+    container: {
+        width: '100%', height: 363, marginTop: 180,
+        backgroundColor: '#21AB66', position: 'relative',
+    },
+    answer: {
+        position: 'absolute', top: '50%', transform: 'translate(-50%, -50%)', fontSize: 100, color: '#FFF', left: '50%',
+    }
+}

--- a/src/components/LiarGame/EnterAnswerComponent.js
+++ b/src/components/LiarGame/EnterAnswerComponent.js
@@ -1,6 +1,8 @@
 import React, {useState} from 'react';
+import LiarAnswerComponent from "./LiarAnswerComponent";
 
-const AnswerComponent = (props) => {
+// 라이어가 정답을 입력하는 컴포넌트, 라이어가 아닌 유저는 대기 화면이 나타난다.
+const EnterAnswerComponent = (props) => {
 
     // *********라이어 화면일 때 쓰이는 코드들*********
     const [answer, setAnswer] = useState("");
@@ -14,15 +16,19 @@ const AnswerComponent = (props) => {
     const [userInfo, setUserInfo] = useState({
         nickname: "홍길동",
         profile: "",
-        isLiar: false, // 실제로 쓰이는 변수
+        isLiar: true, // 실제로 쓰이는 변수
     });
 
+    // '확인' 버튼 클릭 시 실행되는 함수.
+    const [confirmAnswer, setConfirmAnswer] = useState(false); // true 이면, 라이어가 적은 답 보여주는 화면으로 이동
+    const liarAnswerConfirm = () => {
+        setConfirmAnswer(true);
+    }
 
-    // *********대기 유저 화면일 때 쓰이는 코드들*********
 
 
     // 라이어 일 때 화면
-    if (userInfo.isLiar) {
+    if (userInfo.isLiar && !confirmAnswer) {
         return (
             <>
                 {/*카테고리도 파이어베이스에서 가져와서 보여줘야 할 듯*/}
@@ -32,14 +38,14 @@ const AnswerComponent = (props) => {
                     <input type="text" style={styles.textInput} onChange={setData}/>
                 </div>
                 <div>
-                    {answer ? <input type="button" value="확인" style={styles.yesBtn}/> :
+                    {answer ? <input type="button" value="확인" style={styles.yesBtn} onClick={liarAnswerConfirm}/> :
                         <input type="button" value="확인" style={styles.noBtn} disabled/>}
                 </div>
             </>
         )
     }
     // 대기 유저 화면
-    else {
+    else if (!userInfo.isLiar && !confirmAnswer) {
         return (
             <>
                 <div style={styles.category}>카테고리 : 인물</div>
@@ -52,8 +58,16 @@ const AnswerComponent = (props) => {
             </>
         )
     }
+    // 라이어가 적은 답을 보여주는 화면으로 이동
+    else {
+        return (
+            <>
+                <LiarAnswerComponent answer={answer} profile={props.profile} name={props.name}/>
+            </>
+        )
+    }
 }
-export default AnswerComponent
+export default EnterAnswerComponent
 const styles = {
     category: {
         fontSize: 32, marginTop: 125, marginBottom: 29,

--- a/src/components/LiarGame/FailComponent.js
+++ b/src/components/LiarGame/FailComponent.js
@@ -1,19 +1,45 @@
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import Circle from "./images/redCircle.png";
+import WinLiarComponent from "./WinLiarComponent";
 
+// 라이어 지목 실패했을 때 나타나는 컴포넌트, 5초 뒤에 라이어 승리 컴포넌트로 이동한다.
 const FailComponent = (props) => {
-    return(
-        <>
-            <div style={styles.container}>
-                <div style={styles.title}>라이어 지목 실패!</div>
-                <div style={styles.innerContainer}>
-                    <img style={styles.imgStyle} src={props.profile} alt=""/>
-                    <div style={styles.nameStyle}>{props.name}</div>
+    const [winLiar, setWinLiar] = useState(false);
+
+    useEffect(() => {
+        let counter = 0;
+        let interval = setInterval(function () {
+            counter++;
+            if (counter === 5) {
+                clearInterval(interval);
+                setWinLiar(true);
+
+            }
+        }, 1000);
+    }, [])
+
+    if(!winLiar) {
+        return(
+            <>
+                <div style={styles.container}>
+                    <div style={styles.title}>라이어 지목 실패!</div>
+                    <div style={styles.innerContainer}>
+                        <img style={styles.imgStyle} src={props.profile} alt=""/>
+                        <div style={styles.nameStyle}>{props.name}</div>
+                    </div>
+                    <img src={Circle} style={styles.circle} alt="redcircle"/>
                 </div>
-                <img src={Circle} style={styles.circle} alt="redcircle"/>
-            </div>
-        </>
-    )
+            </>
+        )
+    }
+    // 라이어 승리 화면으로 넘어감
+    else {
+        return (
+            <>
+                <WinLiarComponent name={props.name} profile={props.profile}/>
+            </>
+        )
+    }
 }
 
 export default FailComponent

--- a/src/components/LiarGame/LiarAnswerComponent.js
+++ b/src/components/LiarGame/LiarAnswerComponent.js
@@ -1,0 +1,70 @@
+import React, {useEffect, useState} from 'react'
+import AnswerViewComponent from "./AnswerViewComponent";
+import WrongViewComponent from "./WrongViewComponent";
+
+// 라이어가 입력한 정답을 보여주는 컴포넌트
+const LiarAnswerComponent = (props) => {
+
+    const [answerData, setAnswerData] = useState('7번방의 선물'); // 파이어베이스로부터 가져온 정답을 저장할 변수
+    const [isAnswer, setIsAnswer] = useState(false); // 해당 변수가 true이면, 라이어가 정답을 맞춘 것
+    const [changeComponent, setChangeComponent] = useState(false); // 해당 변수가 true가 되면, 정답 또는 오답 화면으로 이동
+
+    // 라이어가 입력한 답을 5초 동안 보여주고 정답, 오답 여부 화면으로 이동
+    useEffect(() => {
+        let counter = 0;
+        let interval = setInterval(function () {
+            counter++;
+            if (counter === 5) {
+                clearInterval(interval);
+                if (answerData === props.answer) {
+                    setIsAnswer(true);
+                    setChangeComponent(true);
+                } else {
+                    setIsAnswer(false);
+                    setChangeComponent(true);
+                }
+
+            }
+        }, 1000);
+    }, []);
+
+    if (!changeComponent) {
+        return (
+            <>
+                {/*liar nickname도 파이어베이스에서 받아와야 할 것 같음*/}
+                <div style={styles.title}>''님이 입력한 제시어</div>
+                <div style={styles.answer}>{props.answer}</div>
+            </>
+        )
+    }
+    // 라이어가 정답을 맞추었을 때 이동할 컴포넌트
+    else if (changeComponent && isAnswer) {
+        return (
+            <>
+                <AnswerViewComponent name={props.name} profile={props.profile}/>
+            </>
+        )
+    }
+    // 라이어가 정답을 맞추지 못했을 때 이동할 컴포넌트
+    else if (changeComponent && !isAnswer) {
+        return (
+            <>
+                <WrongViewComponent name={props.name} profile={props.profile}/>
+            </>
+        )
+    }
+
+}
+
+export default LiarAnswerComponent
+
+const styles = {
+    title: {
+        fontSize: 43.28,
+        marginTop: 200, marginBottom: 46,
+    },
+    answer: {
+        color: '#0C8247',
+        fontSize: 160,
+    },
+}

--- a/src/components/LiarGame/LoseLiarComponent.js
+++ b/src/components/LiarGame/LoseLiarComponent.js
@@ -1,0 +1,44 @@
+import React from 'react'
+
+const LoseLiarComponent = (props) => {
+    return (
+        <>
+            <div style={styles.title}>라이어 패배 !</div>
+            <img style={styles.imgStyle} src={props.profile} alt=""/>
+            <div style={styles.userName}>{props.name}</div>
+            <div style={styles.btnContainer}>
+                <input style={styles.startBtn} type="button" value="다시하기"/>
+                <input style={styles.stopBtn} type="button" value="끝내기"/>
+            </div>
+        </>
+    )
+}
+
+export default LoseLiarComponent
+
+const styles = {
+    title: {
+        marginTop: 60,
+        fontSize: 120,
+        color: '#FCCE39',
+        textShadow: '-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000',
+    },
+    imgStyle: {
+        width: 355, height: 357,
+    },
+    userName: {
+        fontSize: 40,
+    },
+    btnContainer: {
+        marginTop: 49,
+    },
+    startBtn: {
+        width: 146, height: 43, backgroundColor: '#08552E', color: '#FCCE39', border: 'none', marginRight: 115,
+        fontSize: 20, cursor: 'pointer',
+    },
+    stopBtn: {
+        width: 146, height: 43, backgroundColor: '#21AB66', color: '#FCCE39', border: 'none', fontSize: 20,
+        cursor: 'pointer',
+    },
+
+}

--- a/src/components/LiarGame/SuccessComponent.js
+++ b/src/components/LiarGame/SuccessComponent.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react'
 import Circle from "./images/greenCircle.png";
-import AnswerComponent from "./AnswerComponent";
+import EnterAnswerComponent from "./EnterAnswerComponent";
 
 const SuccessComponent = (props) => {
     const [answer, setAnswer] = useState(false); // true 이면 라이어가 정답을 입력하는 화면, 다른 플레이어는 대기 화면으로 이동
@@ -35,7 +35,7 @@ const SuccessComponent = (props) => {
     else {
         return (
             <>
-                <AnswerComponent name={props.name} profile={props.profile}/>
+                <EnterAnswerComponent name={props.name} profile={props.profile}/>
             </>
         )
     }

--- a/src/components/LiarGame/WinLiarComponent.js
+++ b/src/components/LiarGame/WinLiarComponent.js
@@ -1,0 +1,44 @@
+import React from 'react'
+
+const WinLiarComponent = (props) => {
+    return (
+        <>
+            <div style={styles.title}>라이어 승리 !</div>
+            <img style={styles.imgStyle} src={props.profile} alt=""/>
+            <div style={styles.userName}>{props.name}</div>
+            <div style={styles.btnContainer}>
+                <input style={styles.startBtn} type="button" value="다시하기"/>
+                <input style={styles.stopBtn} type="button" value="끝내기"/>
+            </div>
+        </>
+    )
+}
+
+export default WinLiarComponent
+
+const styles = {
+    title: {
+        marginTop: 60,
+        fontSize: 120,
+        color: '#FCCE39',
+        textShadow: '-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000',
+    },
+    imgStyle: {
+        width: 355, height: 357,
+    },
+    userName: {
+        fontSize: 40,
+    },
+    btnContainer: {
+        marginTop: 49,
+    },
+    startBtn: {
+        width: 146, height: 43, backgroundColor: '#08552E', color: '#FCCE39', border: 'none', marginRight: 115,
+        fontSize: 20, cursor: 'pointer',
+    },
+    stopBtn: {
+        width: 146, height: 43, backgroundColor: '#21AB66', color: '#FCCE39', border: 'none', fontSize: 20,
+        cursor: 'pointer',
+    },
+
+}

--- a/src/components/LiarGame/WrongViewComponent.js
+++ b/src/components/LiarGame/WrongViewComponent.js
@@ -1,0 +1,47 @@
+import React, {useEffect, useState} from 'react'
+import LoseLiarComponent from "./LoseLiarComponent";
+
+// 오답 화면을 보여주는 컴포넌트, 3초 뒤 라이어 패배 컴포넌트로 이동
+const WrongViewComponent = (props) => {
+
+    const [changeComponent, setChangeComponent] = useState(false);
+
+    useEffect(() => {
+        let counter = 0;
+        let interval = setInterval(function () {
+            counter++;
+            if (counter === 3) {
+                clearInterval(interval);
+                setChangeComponent(true);
+
+            }
+        }, 1000);
+    }, []);
+
+    if (!changeComponent) {
+        return (
+            <>
+                <div style={styles.container}><span style={styles.answer}>오 - 답</span></div>
+            </>
+        )
+    }
+    else {
+        return (
+            <>
+                <LoseLiarComponent name={props.name} profile={props.profile}/>
+            </>
+        )
+    }
+}
+
+export default WrongViewComponent
+
+const styles = {
+    container: {
+        width: '100%', height: 363, marginTop: 180,
+        backgroundColor: '#B00404', position: 'relative',
+    },
+    answer: {
+        position: 'absolute', top: '50%', transform: 'translate(-50%, -50%)', fontSize: 100, color: '#FFF', left: '50%',
+    }
+}


### PR DESCRIPTION
- 라이어 지목 성공 시 5초 뒤 컴포넌트 이동
    - 라이어 유저는 정답 입력 화면으로 이동
    - 일반 유저는 대기 화면으로 이동
- 라이어가 정답 입력 후 '확인' 버튼 클릭 시 라이어, 일반 유저 모두 라이어가 입력한 제시어 확인 화면으로 이동
- 5초 가 지난 후 정답일 경우 정답 화면, 오답일 경우 오답 화면을 보여줌
- 3초 뒤 라이어가 이겼으면 라이어 승리 화면, 졌으면 라이어 패배 화면으로 이동
- 최종 화면인 라이어 승리(패배) 화면에서 '다시하기', '끝내기' 버튼 기능 구현 미완료